### PR TITLE
fix thinkfan yaml template

### DIFF
--- a/thinkfan.yaml
+++ b/thinkfan.yaml
@@ -1,3 +1,5 @@
+sensors:
+  - tpacpi: /proc/acpi/ibm/thermal
 fans:
   - tpacpi: /proc/acpi/ibm/fan
 


### PR DESCRIPTION
I was simply getting errors for "missing sensors" in yaml
It might be better to use hwmon? i wasn't sure how to set it up though :/